### PR TITLE
Specify minimum required version for Getopt::Long

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,6 +26,8 @@ version = 0.1
 	filename = README.pod
 	location = root
 
+[Prereqs]
+	Getopt::Long = 2.36
 [AutoPrereqs]
 	skips = ^Log::Dispatch::DesktopNotification$
 [NextRelease]


### PR DESCRIPTION
Hi,

I've noticed the [cpan-testers failure report](http://www.cpantesters.org/cpan/report/d28727bc-7c4b-11e4-9696-c7ea56d63282) for you module. It happened because `GetOptionsFromArray` [appeared](https://metacpan.org/changes/distribution/Getopt-Long) in `Getopt::Long` 2.36, but `perl-5.8.8` has only 2.35 bundled. I fixed it by requiring 2.36 in you _dist.ini_ file.

This PR is part of my [advent quest](https://questhub.io/realm/perl/quest/547b4202070ccf750d00010e).

Cheers,
Sergey.
