### PR TITLE
Stop triggering a prove for .# files

### DIFF
--- a/lib/App/Prove/Watch.pm
+++ b/lib/App/Prove/Watch.pm
@@ -85,7 +85,7 @@ sub run {
 			my $doit;
 			foreach my $event (@_) {
 				my $file = basename($event->{path});
-				next if $file =~ m/^(?:\.~)/;
+				next if $file =~ m/^(?:\.[~#])/;
 				
 				$doit++;
 				


### PR DESCRIPTION
Emacs uses a symlink called `.#filename` as a [lockfile to provide safety against multi-user editing](http://www.gnu.org/software/emacs/manual/html_node/emacs/Interlocking.html#Interlocking). I don't need provewatcher to trigger on these changes, as they're done every time I change a file, instead of every time I save it.

Alternatively, `provewatcher` could accept an --ignore option as a regex or something and use it in place of this to filter files more generally, if you'd prefer me to make that change.

Thanks for this awesome module, by the way. I love it :D