### PR TITLE
Add support for before/after prove hooks

### DIFF
--- a/t/002_watcher.t
+++ b/t/002_watcher.t
@@ -52,6 +52,22 @@ describe "A prove watcher" => sub {
 			is($called, 2);
 		};	
 	};
+
+	describe "with before_prove argument" => sub {
+        it "callback should run once on each prove invocation" => sub {
+            my $sut = App::Prove::Watch->new( '--before_prove' => sub { pass("Called") } );
+            $sut->watcher( mock::watcher->new('somefile') );
+            $sut->run(1);
+        };
+    };
+
+    describe "with after_prove argument" => sub {
+        it "callback should run once on each prove invocation" => sub {
+            my $sut = App::Prove::Watch->new( '--after_prove' => sub { pass("Called") } );
+            $sut->watcher( mock::watcher->new('somefile') );
+            $sut->run(1);
+        };
+    };
 };
 
 


### PR DESCRIPTION
Hi there - thanks for the work on this useful module!

I wanted to be able to integrate this with my existing test system, and so I found it useful to allow the user to provide `before_prove` or `after_prove` callbacks, which fire on either side of prove.

Not sure if you're interested in taking it this direction, but if so, you're welcome to it!  (Happy to add a little documentation too, if you'll accept it.)